### PR TITLE
Fixed drive segment in Windows URIs

### DIFF
--- a/example/states-extension/package.json
+++ b/example/states-extension/package.json
@@ -122,8 +122,8 @@
     "scripts": {
         "clean": "rimraf lib",
         "watch": "tsc -w",
-        "postinstall": "node ./node_modules/vscode/bin/install && yarn unzip-ls && yarn build",
-        "unzip-ls": "unzip ./states-language-server.zip -d server/",
+        "prepare": "node ./node_modules/vscode/bin/install && yarn unzip-ls && yarn build",
+        "unzip-ls": "unzip  -o ./states-language-server.zip -d server/",
         "build": "tsc && webpack --mode=development",
         "vscode:prepublish": "webpack --mode=production"
     }

--- a/extension/src/sprotty-vscode-extension.ts
+++ b/extension/src/sprotty-vscode-extension.ts
@@ -97,9 +97,14 @@ export abstract class SprottyVscodeExtension {
         if (!uri || !diagramType)
             return undefined;
         const clientId = diagramType + '_' + SprottyWebview.viewCount++;
+        let uriString = uri.toString();
+        const match = uriString.match(/file:\/\/\/([a-z])%3A/i);
+        if (match) {
+            uriString = 'file:///' + match[1] + ':' + uriString.substring(match[0].length);
+        }
         return {
             diagramType,
-            uri: uri.toString(),
+            uri: uriString,
             clientId
         };
     }


### PR DESCRIPTION
The Sprotty server fails to find the source model if the URI starts with an encoded segment like `file:///c%3A` (TBH I don't know why, IMO Xtext's `UriExtensions` should be able to handle that). This change replaces this prefix with the decoded form `file:///c:`.