### PR TITLE
Catch errors on sending didClose notification

### DIFF
--- a/sprotty-vscode-extension/src/lsp/sprotty-lsp-vscode-extension.ts
+++ b/sprotty-vscode-extension/src/lsp/sprotty-lsp-vscode-extension.ts
@@ -39,11 +39,11 @@ export abstract class SprottyLspVscodeExtension extends SprottyVscodeExtension {
     }
 
     didCloseWebview(identifier: SprottyDiagramIdentifier): void {
-        if (this.webviewMap.delete(this.getKey(identifier))) {
+        super.didCloseWebview(identifier);
+        try {
             this.languageClient.sendNotification(didCloseMessageType, identifier.clientId);
-        }
-        if (this.singleton) {
-            this.singleton = undefined;
+        } catch (err) {
+            // Ignore the error and proceed
         }
     }
 


### PR DESCRIPTION
When the connection to the language server doesn't work, `sendNotification` throws an error. Added a try-catch around it and also called the superclass method to ensure we don't miss anything.