### PR TITLE
Don't use webviewMap when singleton is active

### DIFF
--- a/example/states/extension/package.json
+++ b/example/states/extension/package.json
@@ -164,10 +164,9 @@
     },
     "scripts": {
         "prepare": "yarn run clean && yarn run build",
-        "clean": "rimraf extension/lib extension/pack",
-        "build": "tsc && webpack --mode=production",
-        "watch": "tsc -w",
-        "watch:webpack": "webpack --mode=development --watch",
+        "clean": "rimraf lib pack",
+        "build": "webpack --mode=production",
+        "watch": "webpack --mode=development --watch",
         "publish": "vsce publish"
     }
 }

--- a/example/states/webview/package.json
+++ b/example/states/webview/package.json
@@ -53,9 +53,8 @@
   },
   "scripts": {
     "prepare": "yarn run clean && yarn run build",
-    "clean": "rimraf lib pack",
-    "build": "tsc && webpack --mode=development",
-    "watch:": "tsc -w",
-    "watch:webpack": "webpack --mode=development --watch"
+    "clean": "rimraf lib",
+    "build": "webpack --mode=development",
+    "watch": "webpack --mode=development --watch"
   }
 }

--- a/sprotty-vscode-extension/src/sprotty-vscode-extension.ts
+++ b/sprotty-vscode-extension/src/sprotty-vscode-extension.ts
@@ -34,15 +34,16 @@ export abstract class SprottyVscodeExtension {
                 const identifier = await this.createDiagramIdentifier(commandArgs);
                 if (identifier) {
                     const key = this.getKey(identifier);
-                    let webView = this.singleton || this.webviewMap.get(key);
+                    let webView = this.singleton ?? this.webviewMap.get(key);
                     if (webView) {
                         webView.reloadContent(identifier);
                         webView.diagramPanel.reveal(webView.diagramPanel.viewColumn);
                     } else {
                         webView = this.createWebView(identifier);
-                        this.webviewMap.set(key, webView);
                         if (webView.singleton) {
                             this.singleton = webView;
+                        } else {
+                            this.webviewMap.set(key, webView);
                         }
                     }
                 }
@@ -78,9 +79,13 @@ export abstract class SprottyVscodeExtension {
     }
 
     protected findActiveWebview(): SprottyWebview | undefined {
+        if (this.singleton && this.singleton.diagramPanel.active) {
+            return this.singleton;
+        }
         for (const webview of this.webviewMap.values()) {
-            if (webview.diagramPanel.active)
+            if (webview.diagramPanel.active) {
                 return webview;
+            }
         }
         return undefined;
     }


### PR DESCRIPTION
Fixes #42. This change avoids accessing a webview that has been previously closed.