### PR TITLE
Update vscode-languageclient dependency

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,14 +1,4 @@
 tasks:
-  - init: >
-      example/states/language-server/gradlew -p example/states/language-server/ build &&
+  - init: |
+      example/states/language-server/gradlew -p example/states/language-server/ build
       yarn 
-github:
-  prebuilds:
-    master: true
-    branches: true
-    pullRequests: true
-    pullRequestsFromForks: false
-    addCheck: true
-    addComment: false
-    addBadge: false
-    addLabel: false

--- a/example/states/extension/package.json
+++ b/example/states/extension/package.json
@@ -157,8 +157,7 @@
         "ts-loader": "^8.0.3",
         "tslint": "^5.11.0",
         "typescript": "3.8.3",
-        "vscode-languageclient": "^5.2.1",
-        "vscode-languageserver": "^5.2.1",
+        "vscode-languageclient": "^7.0.0",
         "webpack": "^4.44.1",
         "webpack-cli": "^3.3.12"
     },

--- a/example/states/extension/src/states-lsp-extension.ts
+++ b/example/states/extension/src/states-lsp-extension.ts
@@ -16,7 +16,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 import { LspLabelEditActionHandler, WorkspaceEditActionHandler, SprottyLspEditVscodeExtension } from "sprotty-vscode/lib/lsp/editing";
 import { SprottyDiagramIdentifier, SprottyLspWebview } from 'sprotty-vscode/lib/lsp';
 import { SprottyWebview } from 'sprotty-vscode/lib/sprotty-webview';

--- a/example/states/language-server/build.gradle
+++ b/example/states/language-server/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 subprojects {
-	ext.xtextVersion = '2.25.0'
+	ext.xtextVersion = '2.26.0.M2'
 	ext.sprottyVersion = '0.9.1'
 	ext.elkVersion = '0.7.1'
 	

--- a/sprotty-vscode-extension/package.json
+++ b/sprotty-vscode-extension/package.json
@@ -44,8 +44,7 @@
   "dependencies": {
     "path": "^0.12.7",
     "sprotty-vscode-protocol": "^0.0.5",
-    "vscode-languageclient": "^5.2.1",
-    "vscode-languageserver": "^5.2.1"
+    "vscode-languageclient": "^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^8.0.0",

--- a/sprotty-vscode-extension/src/lsp/editing/lsp-label-edit-action-handler.ts
+++ b/sprotty-vscode-extension/src/lsp/editing/lsp-label-edit-action-handler.ts
@@ -18,17 +18,9 @@ import { Action } from 'sprotty-protocol';
 import { LspLabelEditAction } from 'sprotty-vscode-protocol/lib/lsp/editing';
 import { QuickPickItem, window, workspace, WorkspaceEdit, TextEdit } from 'vscode';
 import {
-    CompletionItem,
-    CompletionItemKind,
-    CompletionList,
-    CompletionRequest,
-    LanguageClient,
-    PrepareRenameRequest,
-    RenameParams,
-    RenameRequest,
-    TextDocumentPositionParams,
+    CompletionItem, CompletionItemKind, CompletionList, CompletionRequest, CommonLanguageClient,
+    PrepareRenameRequest, RenameParams, RenameRequest, TextDocumentPositionParams
 } from 'vscode-languageclient';
-
 import { ActionHandler } from '../../action-handler';
 import { SprottyLspVscodeExtension } from '../sprotty-lsp-vscode-extension';
 import { SprottyWebview } from '../../sprotty-webview';
@@ -53,7 +45,7 @@ export class LspLabelEditActionHandler implements ActionHandler {
         return false;
     }
 
-    protected get languageClient(): LanguageClient {
+    protected get languageClient(): CommonLanguageClient {
         return (this.webview.extension as SprottyLspVscodeExtension).languageClient;
     }
 

--- a/sprotty-vscode-extension/src/lsp/protocol.ts
+++ b/sprotty-vscode-extension/src/lsp/protocol.ts
@@ -20,9 +20,9 @@ import { ActionMessage } from 'sprotty-protocol';
 /////////////////////////////////////
 // Sprotty LSP extensions
 
-export const acceptMessageType = new NotificationType<ActionMessage, void>('diagram/accept');
-export const didCloseMessageType = new NotificationType<string, void>('diagram/didClose');
-export const openInTextEditorMessageType = new NotificationType<OpenInTextEditorMessage, void>('diagram/openInTextEditor');
+export const acceptMessageType = new NotificationType<ActionMessage>('diagram/accept');
+export const didCloseMessageType = new NotificationType<string>('diagram/didClose');
+export const openInTextEditorMessageType = new NotificationType<OpenInTextEditorMessage>('diagram/openInTextEditor');
 
 export interface OpenInTextEditorMessage {
     location: Location

--- a/sprotty-vscode-extension/src/lsp/sprotty-lsp-vscode-extension.ts
+++ b/sprotty-vscode-extension/src/lsp/sprotty-lsp-vscode-extension.ts
@@ -15,14 +15,14 @@
  ********************************************************************************/
 
 import * as vscode from 'vscode';
-import { Emitter, LanguageClient } from 'vscode-languageclient';
+import { Emitter, CommonLanguageClient } from 'vscode-languageclient';
 import { acceptMessageType, didCloseMessageType, OpenInTextEditorMessage, openInTextEditorMessageType } from './protocol';
 import { ActionMessage } from 'sprotty-protocol';
 import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import { SprottyVscodeExtension } from '../sprotty-vscode-extension';
 
 export abstract class SprottyLspVscodeExtension extends SprottyVscodeExtension {
-    readonly languageClient: LanguageClient;
+    readonly languageClient: CommonLanguageClient;
 
     protected acceptFromLanguageServerEmitter = new Emitter<ActionMessage>();
 
@@ -30,8 +30,8 @@ export abstract class SprottyLspVscodeExtension extends SprottyVscodeExtension {
         super(extensionPrefix, context);
         this.languageClient = this.activateLanguageClient(context);
         this.languageClient.onReady().then(() => {
-            this.languageClient.onNotification(acceptMessageType, message => this.acceptFromLanguageServerEmitter.fire(message));
-            this.languageClient.onNotification(openInTextEditorMessageType, message => this.openInTextEditor(message));
+            this.languageClient.onNotification(acceptMessageType, (message: ActionMessage) => this.acceptFromLanguageServerEmitter.fire(message));
+            this.languageClient.onNotification(openInTextEditorMessageType, (message: OpenInTextEditorMessage) => this.openInTextEditor(message));
         });
     }
 
@@ -48,7 +48,7 @@ export abstract class SprottyLspVscodeExtension extends SprottyVscodeExtension {
         }
     }
 
-    protected abstract activateLanguageClient(context: vscode.ExtensionContext): LanguageClient;
+    protected abstract activateLanguageClient(context: vscode.ExtensionContext): CommonLanguageClient;
 
     deactivateLanguageClient(): Thenable<void> {
         if (!this.languageClient)

--- a/sprotty-vscode-extension/src/lsp/sprotty-lsp-webview.ts
+++ b/sprotty-vscode-extension/src/lsp/sprotty-lsp-webview.ts
@@ -13,9 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
+
 import { isActionMessage } from 'sprotty-protocol';
-import { isNotificationMessage, isRequestMessage, ResponseMessage } from 'vscode-jsonrpc/lib/messages';
-import { LanguageClient } from 'vscode-languageclient';
+import { isNotificationMessage, isRequestMessage, ResponseMessage } from 'vscode-jsonrpc/lib/common/messages';
+import { CommonLanguageClient } from 'vscode-languageclient';
 
 import { acceptMessageType } from './protocol';
 import { SprottyLspVscodeExtension } from './sprotty-lsp-vscode-extension';
@@ -38,7 +39,7 @@ export class SprottyLspWebview extends SprottyWebview {
         return Promise.all([super.ready(), this.languageClient.onReady()]) as any;
     }
 
-    protected get languageClient(): LanguageClient {
+    protected get languageClient(): CommonLanguageClient {
         return this.extension.languageClient;
     }
 

--- a/sprotty-vscode-extension/src/sprotty-webview.ts
+++ b/sprotty-vscode-extension/src/sprotty-webview.ts
@@ -20,7 +20,7 @@ import * as vscode from 'vscode';
 
 import { ActionHandler } from './action-handler';
 import { SprottyVscodeExtension, serializeUri } from './sprotty-vscode-extension';
-import { isResponseMessage, ResponseMessage } from 'vscode-jsonrpc/lib/messages';
+import { isResponseMessage, ResponseMessage } from 'vscode-jsonrpc/lib/common/messages';
 
 export interface SprottyWebviewOptions {
     extension: SprottyVscodeExtension

--- a/sprotty-vscode-protocol/package.json
+++ b/sprotty-vscode-protocol/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "path": "^0.12.7",
     "sprotty-protocol": "~0.11.0",
-    "vscode-languageserver-protocol": "^3.14.1"
+    "vscode-languageserver-protocol": "^3.16.0"
   },
   "devDependencies": {
     "@types/node": "^8.0.0",

--- a/sprotty-vscode-webview/package.json
+++ b/sprotty-vscode-webview/package.json
@@ -42,7 +42,7 @@
     "reflect-metadata": "^0.1.12",
     "sprotty": "~0.11.1",
     "sprotty-vscode-protocol": "^0.0.5",
-    "vscode-uri": "2.1.1"
+    "vscode-uri": "^3.0.2"
   },
   "devDependencies": {
     "rimraf": "latest",

--- a/sprotty-vscode-webview/src/lsp/editing/language-client-proxy.ts
+++ b/sprotty-vscode-webview/src/lsp/editing/language-client-proxy.ts
@@ -15,8 +15,8 @@
  ********************************************************************************/
 import { injectable } from 'inversify';
 import { NotificationType, NotificationType0, RequestType, RequestType0 } from 'vscode-jsonrpc';
-import { isResponseMessage } from 'vscode-jsonrpc/lib/messages';
-import { CancellationToken, NotificationMessage, RequestMessage, RPCMessageType } from 'vscode-languageserver-protocol';
+import { isResponseMessage } from 'vscode-jsonrpc/lib/common/messages';
+import { CancellationToken, NotificationMessage, RequestMessage, MessageSignature } from 'vscode-languageserver-protocol';
 import { vscodeApi } from '../../vscode-api';
 
 @injectable()
@@ -47,13 +47,13 @@ export class LanguageClientProxy {
         });
     }
 
-    async sendRequest<R, E, RO>(type: RequestType0<R, E, RO>, token?: CancellationToken): Promise<R>;
-    async sendRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, params: P, token?: CancellationToken): Promise<R>;
-    async sendRequest<R>(type: RPCMessageType, ...params: any[]): Promise<R> {
+    async sendRequest<R, E>(type: RequestType0<R, E>, token?: CancellationToken): Promise<R>;
+    async sendRequest<P, R, E>(type: RequestType<P, R, E>, params: P, token?: CancellationToken): Promise<R>;
+    async sendRequest<R>(signature: MessageSignature, ...params: any[]): Promise<R> {
         if (CancellationToken.is(params[params.length - 1]))
             params.pop();
         vscodeApi.postMessage(<RequestMessage> {
-            method: type.method,
+            method: signature.method,
             id: this.currentNumber,
             jsonrpc: 'request',
             params: params[0]
@@ -66,11 +66,11 @@ export class LanguageClientProxy {
         return promise;
     }
 
-    sendNotification<RO>(type: NotificationType0<RO>): void;
-    sendNotification<P, RO>(type: NotificationType<P, RO>, params?: P): void;
-    sendNotification<P>(type: RPCMessageType, params?: P): void {
+    sendNotification(type: NotificationType0): void;
+    sendNotification<P>(type: NotificationType<P>, params?: P): void;
+    sendNotification<P>(signature: MessageSignature, params?: P): void {
         vscodeApi.postMessage(<NotificationMessage> {
-            method: type.method,
+            method: signature.method,
             jsonrpc: 'notify',
             params
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,6 +3872,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -5371,6 +5378,13 @@ semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+semver@^7.3.4:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
@@ -6278,67 +6292,37 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vscode-jsonrpc@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
-  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
+vscode-jsonrpc@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
+  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-jsonrpc@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
-  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
-
-vscode-languageclient@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz#7cfc83a294c409f58cfa2b910a8cfeaad0397193"
-  integrity sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==
+vscode-languageclient@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz#b505c22c21ffcf96e167799757fca07a6bad0fb2"
+  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
   dependencies:
-    semver "^5.5.0"
-    vscode-languageserver-protocol "3.14.1"
+    minimatch "^3.0.4"
+    semver "^7.3.4"
+    vscode-languageserver-protocol "3.16.0"
 
-vscode-languageserver-protocol@3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
-  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
+vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
+  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
   dependencies:
-    vscode-jsonrpc "^4.0.0"
-    vscode-languageserver-types "3.14.0"
+    vscode-jsonrpc "6.0.0"
+    vscode-languageserver-types "3.16.0"
 
-vscode-languageserver-protocol@^3.14.1:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
-  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
-  dependencies:
-    vscode-jsonrpc "^5.0.1"
-    vscode-languageserver-types "3.15.1"
+vscode-languageserver-types@3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
+  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
-vscode-languageserver-types@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
-  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
-
-vscode-languageserver-types@3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
-
-vscode-languageserver@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz#0d2feddd33f92aadf5da32450df498d52f6f14eb"
-  integrity sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==
-  dependencies:
-    vscode-languageserver-protocol "3.14.1"
-    vscode-uri "^1.0.6"
-
-vscode-uri@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.1.tgz#5aa1803391b6ebdd17d047f51365cf62c38f6e90"
-  integrity sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==
-
-vscode-uri@^1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
-  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
+vscode-uri@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
+  integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
 
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"
@@ -6559,6 +6543,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^10.0.0:
   version "10.1.0"


### PR DESCRIPTION
Closes #48. This is a follow-up of #52 with the following differences:

 * Fixed states example by updating Xtext
 * Removed dependency to `vscode-languageserver` (we are using only the client code here)
 * Avoided white space changes and kept `yarn.lock` largely as before