### PR TITLE
Fixed the command to build the lib & examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The repo is structured as follows
 
 ## Development
 
-Compile the library code and the example
+Compile the library code and the examples
 ```
-example/states/language-server/gradlew -p example/states/language-server/ build &&
-yarn
+examples/states-xtext/language-server/gradlew -p examples/states-xtext/language-server/ build && yarn
 ```
+


### PR DESCRIPTION
I had some issues getting the build working, since I was using PowerShell on WIndows.

This update corrects the command in the ReadMe to build the library & examples. Not that it is a bit counterintuitive having to run a gradle script from within the Xtext example to build the library.
Also, the "yarn" command still doesn't work with PowerShell (at least there are some commands used like `cp` that isn't known there. So you could consider adding a line to the readme like this:

> Running "yarn" won't work using PowerShell, we recommend using a different, Windows-independent command-line tool.