### PR TITLE
Added TS option to enforce explicit override

### DIFF
--- a/configs/base.tsconfig.json
+++ b/configs/base.tsconfig.json
@@ -12,6 +12,7 @@
         "module": "commonjs",
         "moduleResolution": "node",
         "noUnusedLocals": true,
+        "noImplicitOverride": true,
         "skipLibCheck": true,
         "strict": true,
         "strictPropertyInitialization": false,

--- a/examples/states-langium/language-server/src/layout-config.ts
+++ b/examples/states-langium/language-server/src/layout-config.ts
@@ -20,7 +20,7 @@ import { SGraph, SModelIndex, SNode, SPort } from 'sprotty-protocol';
 
 export class StatesLayoutConfigurator extends DefaultLayoutConfigurator {
 
-    protected graphOptions(sgraph: SGraph, index: SModelIndex): LayoutOptions {
+    protected override graphOptions(sgraph: SGraph, index: SModelIndex): LayoutOptions {
         return {
             'org.eclipse.elk.direction': 'DOWN',
             'org.eclipse.elk.spacing.nodeNode': '30.0',
@@ -28,14 +28,14 @@ export class StatesLayoutConfigurator extends DefaultLayoutConfigurator {
         };
     }
 
-    protected nodeOptions(snode: SNode, index: SModelIndex): LayoutOptions {
+    protected override nodeOptions(snode: SNode, index: SModelIndex): LayoutOptions {
         return {
             'org.eclipse.elk.portAlignment.default': 'CENTER',
             'org.eclipse.elk.portConstraints': 'FIXED_SIDE'
         };
     }
 
-    protected portOptions(sport: SPort, index: SModelIndex): LayoutOptions {
+    protected override portOptions(sport: SPort, index: SModelIndex): LayoutOptions {
         return {
             'org.eclipse.elk.port.side': 'EAST',
             'org.eclipse.elk.port.borderOffset': '3.0'

--- a/examples/states-webview/src/custom-edge-router.ts
+++ b/examples/states-webview/src/custom-edge-router.ts
@@ -16,7 +16,7 @@
 import { ManhattanEdgeRouter, SRoutableElement, ManhattanRouterOptions, edgeInProgressID } from "sprotty";
 
 export class CustomRouter extends ManhattanEdgeRouter {
-    getOptions(edge: SRoutableElement): ManhattanRouterOptions {
+    override getOptions(edge: SRoutableElement): ManhattanRouterOptions {
         const defaultOptions = super.getOptions(edge);
         return edge.id === edgeInProgressID
             ? { ...defaultOptions, standardDistance: 1 }

--- a/examples/states-webview/src/main.ts
+++ b/examples/states-webview/src/main.ts
@@ -30,7 +30,7 @@ export class StatesSprottyStarter extends SprottyLspEditStarter {
         return createStateDiagramContainer(diagramIdentifier.clientId);
     }
 
-    protected addVscodeBindings(container: Container, diagramIdentifier: SprottyDiagramIdentifier): void {
+    protected override addVscodeBindings(container: Container, diagramIdentifier: SprottyDiagramIdentifier): void {
         super.addVscodeBindings(container, diagramIdentifier);
         configureModelElement(container, 'button:create', PaletteButton, PaletteButtonView);
     }

--- a/examples/states-webview/src/model.ts
+++ b/examples/states-webview/src/model.ts
@@ -21,19 +21,19 @@ import {
 import { Action, SEdge as SEdgeSchema } from 'sprotty-protocol';
 
 export class StatesEdge extends SEdge {
-    routerKind = ManhattanEdgeRouter.KIND;
-    targetAnchorCorrection = Math.sqrt(5);
+    override routerKind = ManhattanEdgeRouter.KIND;
+    override targetAnchorCorrection = Math.sqrt(5);
 }
 
 export class StatesEdgeLabel extends SLabel {
-    edgePlacement = <EdgePlacement> {
+    override edgePlacement = <EdgePlacement> {
         rotate: true,
         position: 0.6
     };
 }
 
 export class StatesNode extends RectangularNode {
-    canConnect(routable: SRoutableElement, role: string) {
+    override canConnect(routable: SRoutableElement, role: string) {
         return true;
     }
 }

--- a/examples/states-webview/src/views.tsx
+++ b/examples/states-webview/src/views.tsx
@@ -22,7 +22,7 @@ import { injectable } from 'inversify';
 @injectable()
 export class PolylineArrowEdgeView extends PolylineEdgeView {
 
-    protected renderAdditionals(edge: SEdge, segments: Point[], context: RenderingContext): VNode[] {
+    protected override renderAdditionals(edge: SEdge, segments: Point[], context: RenderingContext): VNode[] {
         const p1 = segments[segments.length - 2];
         const p2 = segments[segments.length - 1];
         return [

--- a/sprotty-vscode-extension/src/lsp/editing/sprotty-lsp-edit-vscode-extension.ts
+++ b/sprotty-vscode-extension/src/lsp/editing/sprotty-lsp-edit-vscode-extension.ts
@@ -19,7 +19,7 @@ import { SprottyLspVscodeExtension } from '../sprotty-lsp-vscode-extension';
 import { DeleteWithWorkspaceEditAction } from 'sprotty-vscode-protocol/lib/lsp/editing';
 
 export abstract class SprottyLspEditVscodeExtension extends SprottyLspVscodeExtension {
-    protected registerCommands() {
+    protected override registerCommands() {
         super.registerCommands();
         this.context.subscriptions.push(
             vscode.commands.registerCommand(this.extensionPrefix + '.diagram.delete', (...commandArgs: any) => {

--- a/sprotty-vscode-extension/src/lsp/sprotty-lsp-vscode-extension.ts
+++ b/sprotty-vscode-extension/src/lsp/sprotty-lsp-vscode-extension.ts
@@ -37,7 +37,7 @@ export abstract class SprottyLspVscodeExtension extends SprottyVscodeExtension {
         return this.acceptFromLanguageServerEmitter.event(listener);
     }
 
-    didCloseWebview(identifier: SprottyDiagramIdentifier): void {
+    override didCloseWebview(identifier: SprottyDiagramIdentifier): void {
         super.didCloseWebview(identifier);
         try {
             this.languageClient.sendNotification(didCloseMessageType, identifier.clientId);

--- a/sprotty-vscode-extension/src/lsp/sprotty-lsp-webview.ts
+++ b/sprotty-vscode-extension/src/lsp/sprotty-lsp-webview.ts
@@ -25,11 +25,11 @@ import { SprottyWebview, SprottyWebviewOptions } from '../sprotty-webview';
 
 export class SprottyLspWebview extends SprottyWebview {
 
-    static viewCount = 0;
+    static override viewCount = 0;
 
-    readonly extension: SprottyLspVscodeExtension;
+    override readonly extension: SprottyLspVscodeExtension;
 
-    constructor(protected options: SprottyWebviewOptions) {
+    constructor(protected override options: SprottyWebviewOptions) {
         super(options);
         if (!(options.extension instanceof SprottyLspVscodeExtension))
             throw new Error('SprottyLspWebview must be initialized with a SprottyLspVscodeExtension');
@@ -39,12 +39,12 @@ export class SprottyLspWebview extends SprottyWebview {
         return this.extension.languageClient;
     }
 
-    protected async connect() {
+    protected override async connect() {
         super.connect();
         this.disposables.push(this.extension.onAcceptFromLanguageServer(message => this.sendToWebview(message)));
     }
 
-    protected async receiveFromWebview(message: any): Promise<boolean> {
+    protected override async receiveFromWebview(message: any): Promise<boolean> {
         const shouldPropagate = await super.receiveFromWebview(message);
         if (shouldPropagate) {
             if (isActionMessage(message)) {

--- a/sprotty-vscode-webview/src/disabled-keytool.ts
+++ b/sprotty-vscode-webview/src/disabled-keytool.ts
@@ -21,7 +21,7 @@ import { VNode } from "snabbdom";
  * Key mappings should be provided via the vscode extensions's `package.json`.
  */
 export class DisabledKeyTool extends KeyTool {
-    decorate(vnode: VNode, element: SModelElement): VNode {
+    override decorate(vnode: VNode, element: SModelElement): VNode {
         return vnode;
     }
 }

--- a/sprotty-vscode-webview/src/lsp/editing/code-action-popup-palette.ts
+++ b/sprotty-vscode-webview/src/lsp/editing/code-action-popup-palette.ts
@@ -83,7 +83,7 @@ export class PaletteMouseListener extends PopupHoverMouseListener {
 
     @inject(CodeActionProvider) codeActionProvider: CodeActionProvider;
 
-    mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    override mouseDown(target: SModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
         if (target instanceof PaletteButton) {
             return [this.getWorkspaceEditAction(target)];
         }

--- a/sprotty-vscode-webview/src/lsp/editing/sprotty-lsp-edit-starter.ts
+++ b/sprotty-vscode-webview/src/lsp/editing/sprotty-lsp-edit-starter.ts
@@ -28,7 +28,7 @@ import { VscodeLspEditDiagramServer } from './vscode-lsp-edit-diagram-server';
 import { DeleteWithWorkspaceEditCommand } from './delete-with-workspace-edit';
 
 export abstract class SprottyLspEditStarter extends SprottyStarter {
-    protected addVscodeBindings(container: Container, diagramIdentifier: SprottyDiagramIdentifier) {
+    protected override addVscodeBindings(container: Container, diagramIdentifier: SprottyDiagramIdentifier) {
         super.addVscodeBindings(container, diagramIdentifier);
         container.rebind(VscodeDiagramServer).to(VscodeLspEditDiagramServer);
         container.bind(EditDiagramLocker).toSelf().inSingletonScope();

--- a/sprotty-vscode-webview/src/lsp/editing/traceable.ts
+++ b/sprotty-vscode-webview/src/lsp/editing/traceable.ts
@@ -60,7 +60,7 @@ export function getURI(traceable: Traceable): URI {
 }
 
 export class TraceableMouseListener extends MouseListener {
-    doubleClick(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
+    override doubleClick(target: SModelElement, event: WheelEvent): (Action | Promise<Action>)[] {
         const traceable = findParent(target, (element) => isTraceable(element));
         if (traceable)
             return [ OpenAction.create(traceable.id) ];

--- a/sprotty-vscode-webview/src/lsp/editing/vscode-lsp-edit-diagram-server.ts
+++ b/sprotty-vscode-webview/src/lsp/editing/vscode-lsp-edit-diagram-server.ts
@@ -25,14 +25,14 @@ import { getRange, getURI, isTraceable } from './traceable';
 
 export class VscodeLspEditDiagramServer extends VscodeDiagramServer {
 
-    initialize(registry: ActionHandlerRegistry) {
+    override initialize(registry: ActionHandlerRegistry) {
         super.initialize(registry);
         registry.register(EditLabelAction.KIND, this);
         registry.register(WorkspaceEditAction.KIND, this);
         registry.register("reconnect", this);
     }
 
-    handleLocally(action: Action): boolean {
+    override handleLocally(action: Action): boolean {
         if (action.kind === EditLabelAction.KIND) {
             const label = this.getElement((action as EditLabelAction).labelId);
             if (label && getBasicType(label) === 'label' && isTraceable(label)) {

--- a/sprotty-vscode-webview/src/vscode-diagram-server.ts
+++ b/sprotty-vscode-webview/src/vscode-diagram-server.ts
@@ -31,7 +31,7 @@ export class VscodeDiagramServer extends DiagramServerProxy {
     @inject(VscodeDiagramWidgetFactory) diagramWidgetFactory: VscodeDiagramWidgetFactory;
     @inject(IRootPopupModelProvider)@optional() protected rootPopupModelProvider: IRootPopupModelProvider;
 
-    initialize(registry: ActionHandlerRegistry) {
+    override initialize(registry: ActionHandlerRegistry) {
         super.initialize(registry);
         registry.register(SelectCommand.KIND, this);
         window.addEventListener('message', message => {
@@ -45,7 +45,7 @@ export class VscodeDiagramServer extends DiagramServerProxy {
         this.vscodeApi.postMessage(message);
     }
 
-    handleLocally(action: Action): boolean {
+    override handleLocally(action: Action): boolean {
         if (action.kind === RequestPopupModelAction.KIND) {
             return this.handleRequestPopupModel(action as RequestPopupModelAction);
         } else {
@@ -53,7 +53,7 @@ export class VscodeDiagramServer extends DiagramServerProxy {
         }
     }
 
-    protected handleServerStateAction(status: ServerStatusAction): boolean {
+    protected override handleServerStateAction(status: ServerStatusAction): boolean {
         this.diagramWidgetFactory().setStatus(status);
         return false;
     }


### PR DESCRIPTION
With TypeScript 4.3, an option to enforce the `override` keyword was introduced. Reasons for enabling this:

 - When you click on the `override` keyword, the editor jumps to the superclass declaration of that member.
 - When refactoring a method that is overridden somewhere, breaking changes can slip through without noticing if the method is implicitly overridden. Making that explicit reveals the breakage at compile time.