### PR TITLE
Switch TS target to ES2017

### DIFF
--- a/configs/base.tsconfig.json
+++ b/configs/base.tsconfig.json
@@ -16,6 +16,6 @@
         "skipLibCheck": true,
         "strict": true,
         "strictPropertyInitialization": false,
-        "target": "es5"
+        "target": "es2017"
     }
 }


### PR DESCRIPTION
I propose to switch the target compatibility of the TypeScript compiler to ES2017 because that comes with native support for async / await. This greatly increases the readability and probably also the performance of generated code.