### PR TITLE
Use vscode-messenger for communication with webviews

### DIFF
--- a/examples/states-langium/extension/package.json
+++ b/examples/states-langium/extension/package.json
@@ -175,7 +175,7 @@
         "@types/node": "^12.12.6",
         "@types/vscode": "1.50.0",
         "source-map-loader": "^3.0.0",
-        "sprotty-vscode": "^0.4.0",
+        "sprotty-vscode": "0.4.0",
         "states-language-server": "^0.0.0",
         "states-sprotty-webview": "^0.0.8",
         "ts-loader": "^9.2.6",

--- a/examples/states-webview/package.json
+++ b/examples/states-webview/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "reflect-metadata": "^0.1.13",
     "sprotty": "~0.12.0",
-    "sprotty-vscode-webview": "^0.4.0"
+    "sprotty-vscode-webview": "0.4.0"
   },
   "devDependencies": {
     "css-loader": "^6.5.1",

--- a/examples/states-webview/src/main.ts
+++ b/examples/states-webview/src/main.ts
@@ -26,7 +26,7 @@ import { PaletteButton } from 'sprotty-vscode-webview/lib/lsp/editing';
 
 export class StatesSprottyStarter extends SprottyLspEditStarter {
 
-    createContainer(diagramIdentifier: SprottyDiagramIdentifier) {
+    protected override createContainer(diagramIdentifier: SprottyDiagramIdentifier) {
         return createStateDiagramContainer(diagramIdentifier.clientId);
     }
 
@@ -36,4 +36,4 @@ export class StatesSprottyStarter extends SprottyLspEditStarter {
     }
 }
 
-new StatesSprottyStarter();
+new StatesSprottyStarter().start();

--- a/examples/states-xtext/extension/package.json
+++ b/examples/states-xtext/extension/package.json
@@ -153,7 +153,7 @@
         "@types/node": "^12.12.6",
         "@types/vscode": "1.50.0",
         "source-map-loader": "^3.0.0",
-        "sprotty-vscode": "^0.4.0",
+        "sprotty-vscode": "0.4.0",
         "states-sprotty-webview": "^0.0.8",
         "ts-loader": "^9.2.6",
         "typescript": "~4.6.2",

--- a/packages/sprotty-vscode-protocol/package.json
+++ b/packages/sprotty-vscode-protocol/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "path": "^0.12.7",
     "sprotty-protocol": "~0.12.0",
-    "vscode-languageserver-protocol": "^3.17.2"
+    "vscode-languageserver-protocol": "^3.17.2",
+    "vscode-messenger-common": "^0.4.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.30.0",

--- a/packages/sprotty-vscode-protocol/src/handshake.ts
+++ b/packages/sprotty-vscode-protocol/src/handshake.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2020 TypeFox and others.
+ * Copyright (c) 2020-2022 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { hasOwnProperty } from 'sprotty-protocol';
+import { ActionMessage } from 'sprotty-protocol';
+import { NotificationType } from 'vscode-messenger-common';
 
 // ----------------------------------
 // Initial Handshake
@@ -23,9 +24,7 @@ export interface WebviewReadyMessage {
     readyMessage: string
 }
 
-export function isWebviewReadyMessage(object: unknown): object is WebviewReadyMessage {
-    return hasOwnProperty(object, 'readyMessage');
-}
+export const WebviewReadyNotification: NotificationType<WebviewReadyMessage> = { method: 'WebviewReadyMessage' };
 
 export const SprottyDiagramIdentifier = Symbol('SprottyDiagramIdentifier');
 
@@ -35,6 +34,6 @@ export interface SprottyDiagramIdentifier {
     uri: string
 }
 
-export function isDiagramIdentifier(object: unknown): object is SprottyDiagramIdentifier {
-    return hasOwnProperty(object, ['clientId', 'diagramType', 'uri']);
-}
+export const DiagramIdentifierNotification: NotificationType<SprottyDiagramIdentifier> = { method: 'SprottyDiagramIdentifier' };
+
+export const ActionNotification: NotificationType<ActionMessage> = { method: 'ActionMessage' };

--- a/packages/sprotty-vscode-protocol/src/lsp/editing/editing.ts
+++ b/packages/sprotty-vscode-protocol/src/lsp/editing/editing.ts
@@ -20,7 +20,7 @@ import { Location, WorkspaceEdit } from 'vscode-languageserver-protocol';
 export interface LspLabelEditAction extends Action {
     kind: typeof LspLabelEditAction.KIND
     location: Location
-    editKind: 'xref' | 'name'
+    editKind: 'xref' | 'name'
     initialText: string
 }
 export namespace LspLabelEditAction {

--- a/packages/sprotty-vscode-protocol/src/lsp/index.ts
+++ b/packages/sprotty-vscode-protocol/src/lsp/index.ts
@@ -14,18 +14,4 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Messenger } from "vscode-messenger-webview";
-
-export interface VsCodeApi {
-    postMessage: (message: any) => void
-    getState(): unknown
-    setState(newState: any): void
-}
-
-export const VsCodeApi = Symbol('VsCodeApi');
-export const VsCodeMessenger = Symbol('VsCodeMessenger');
-
-export interface SprottyStarterServices {
-    vscodeApi?: VsCodeApi
-    messenger?: Messenger
-}
+export * from './messages';

--- a/packages/sprotty-vscode-protocol/src/lsp/messages.ts
+++ b/packages/sprotty-vscode-protocol/src/lsp/messages.ts
@@ -14,18 +14,15 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { Messenger } from "vscode-messenger-webview";
+import { NotificationMessage, RequestMessage, ResponseMessage } from 'vscode-jsonrpc';
+import { NotificationType, RequestType } from 'vscode-messenger-common';
 
-export interface VsCodeApi {
-    postMessage: (message: any) => void
-    getState(): unknown
-    setState(newState: any): void
-}
+/**
+ * Notification sent via vscode-messenger to the language server.
+ */
+export const LspNotification: NotificationType<NotificationMessage> = { method: 'LspNotification' };
 
-export const VsCodeApi = Symbol('VsCodeApi');
-export const VsCodeMessenger = Symbol('VsCodeMessenger');
-
-export interface SprottyStarterServices {
-    vscodeApi?: VsCodeApi
-    messenger?: Messenger
-}
+/**
+ * Request sent via vscode-messenger to the language server.
+ */
+export const LspRequest: RequestType<RequestMessage, ResponseMessage> = { method: 'LspRequest' };

--- a/packages/sprotty-vscode-webview/README.md
+++ b/packages/sprotty-vscode-webview/README.md
@@ -4,7 +4,7 @@ This library helps you to implement a [VS Code webview](https://code.visualstudi
 
 # Getting Started
 
-The diagram itself is implemented with the Sprotty API. See the [Sprotty Wiki](https://github.com/eclipse/sprotty/wiki), the [states example](https://github.com/eclipse/sprotty-vscode/tree/master/example/states/webview) and the [Sprotty examples](https://github.com/eclipse/sprotty/tree/master/examples) for reference.
+The diagram itself is implemented with the Sprotty API. See the [Sprotty Wiki](https://github.com/eclipse/sprotty/wiki), the [states example](https://github.com/eclipse/sprotty-vscode/tree/master/examples/states-webview) and the [Sprotty examples](https://github.com/eclipse/sprotty/tree/master/examples) for reference.
 
 The next step is to implement a subclass of `SprottyStarter` and instantiate it in your entry module as shown below.
 
@@ -15,9 +15,11 @@ export class ExampleSprottyStarter extends SprottyStarter {
     }
 }
 
-new ExampleSprottyStarter();
+new ExampleSprottyStarter().start();
 ```
+
+Don't forget to call the `start` method, which initiates the communication to the host extension.
 
 The function `createExampleDiagramContainer` should create an [InversifyJS](https://www.npmjs.com/package/inversify) container with all necessary [Sprotty configuration](https://github.com/eclipse/sprotty/wiki/Dependency-Injection). The passed `clientId` should be used in the `baseDiv` and `hiddenDiv` ids in Sprotty's ViewerOptions.
 
-In case you are connecting your diagram with a [language server](https://microsoft.github.io/language-server-protocol/), e.g. using [Xtext](http://xtext.org), you should use `SprottyLspEditStarter` as superclass.
+In case you are connecting your diagram with a [language server](https://microsoft.github.io/language-server-protocol/), e.g. using [Langium](https://langium.org), you should use `SprottyLspEditStarter` as superclass.

--- a/packages/sprotty-vscode-webview/package.json
+++ b/packages/sprotty-vscode-webview/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "sprotty": "~0.12.0",
     "sprotty-vscode-protocol": "~0.4.0",
+    "vscode-messenger-webview": "^0.4.3",
     "vscode-uri": "^3.0.6"
   },
   "devDependencies": {

--- a/packages/sprotty-vscode-webview/src/lsp/editing/delete-with-workspace-edit.ts
+++ b/packages/sprotty-vscode-webview/src/lsp/editing/delete-with-workspace-edit.ts
@@ -43,7 +43,7 @@ export class DeleteWithWorkspaceEditCommand extends Command {
                 const source = index.getById(e.sourceId);
                 const target = index.getById(e.targetId);
                 if (this.shouldDeleteParent(source)
-                    || this.shouldDeleteParent(target))
+                    || this.shouldDeleteParent(target))
                     elements.add(e);
             }
         });
@@ -107,7 +107,7 @@ export class DeleteWithWorkspaceEditCommand extends Command {
     }
 
     protected shouldDeleteParent(source: SModelElement | undefined): boolean {
-        while (source) {
+        while (source) {
             if (this.shouldDelete(source)) {
                 return true;
             }

--- a/packages/sprotty-vscode-webview/src/lsp/editing/edit-diagram-locker.ts
+++ b/packages/sprotty-vscode-webview/src/lsp/editing/edit-diagram-locker.ts
@@ -40,7 +40,7 @@ export class EditDiagramLocker implements IDiagramLocker {
 
     allowEdit = true;
 
-    isAllowed(action: Action): boolean {
-        return this.allowEdit || this.nonEditActions.indexOf(action.kind) >= 0;
+    isAllowed(action: Action): boolean {
+        return this.allowEdit || this.nonEditActions.indexOf(action.kind) >= 0;
     }
 }

--- a/packages/sprotty-vscode-webview/src/lsp/editing/traceable.ts
+++ b/packages/sprotty-vscode-webview/src/lsp/editing/traceable.ts
@@ -23,14 +23,14 @@ export interface Traceable extends SModelExtension {
     trace: string
 }
 
-export function isTraceable<T extends SModelElement | SModelElementSchema>(element: T): element is Traceable & T {
+export function isTraceable<T extends SModelElement | SModelElementSchema>(element: T): element is Traceable & T {
    return !!(element as any).trace && !!getRange((element as any).trace);
 }
 
 export function getRange(traceable: Traceable): Range;
 export function getRange(trace: string): Range | undefined;
 export function getRange(trace: object): Range | undefined;
-export function getRange(thing: string | Traceable | object): Range | undefined {
+export function getRange(thing: string | Traceable | object): Range | undefined {
     const trace = typeof thing === 'string'
         ? thing
         : (thing as any).trace;
@@ -38,7 +38,7 @@ export function getRange(thing: string | Traceable | object): Range | undefine
         return undefined;
     const query = URI.parse(trace).query;
     const numbers = query.split(/[:-]/).map(s => parseInt(s, 10));
-    if (numbers.length !== 4 || numbers.find(isNaN) !== undefined)
+    if (numbers.length !== 4 || numbers.find(isNaN) !== undefined)
         return undefined;
     return <Range> {
         start: {

--- a/packages/sprotty-vscode-webview/src/lsp/editing/vscode-lsp-edit-diagram-server.ts
+++ b/packages/sprotty-vscode-webview/src/lsp/editing/vscode-lsp-edit-diagram-server.ts
@@ -52,7 +52,7 @@ export class VscodeLspEditDiagramServer extends VscodeDiagramServer {
         return super.handleLocally(action);
     }
 
-    protected getElement(elementId: string): SModelElementSchema | undefined {
+    protected getElement(elementId: string): SModelElementSchema | undefined {
         const index = new SModelIndex();
         index.add(this.currentRoot);
         return index.getById(elementId);

--- a/packages/sprotty-vscode-webview/src/sprotty-starter.ts
+++ b/packages/sprotty-vscode-webview/src/sprotty-starter.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018 TypeFox and others.
+ * Copyright (c) 2018-2022 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,56 +16,71 @@
 
 import { Container } from 'inversify';
 import { DiagramServerProxy, KeyTool, TYPES } from 'sprotty';
-import { isDiagramIdentifier, SprottyDiagramIdentifier, WebviewReadyMessage } from 'sprotty-vscode-protocol';
+import { DiagramIdentifierNotification, SprottyDiagramIdentifier, WebviewReadyNotification } from 'sprotty-vscode-protocol';
+import { HOST_EXTENSION } from 'vscode-messenger-common';
+import { Messenger } from 'vscode-messenger-webview';
 import { DisabledKeyTool } from './disabled-keytool';
-import { SprottyStarterServices, VsCodeApi } from './services';
+import { SprottyStarterServices, VsCodeApi, VsCodeMessenger } from './services';
 import { VscodeDiagramServer } from './vscode-diagram-server';
 import { VscodeDiagramWidget, VscodeDiagramWidgetFactory } from './vscode-diagram-widget';
 
 declare function acquireVsCodeApi(): VsCodeApi;
 
+/**
+ * Main entry class for running Sprotty in a webview. Call the `start` method to begin sending and receiving messages
+ * with the host extension.
+ */
 export abstract class SprottyStarter {
 
+    readonly vscodeApi: VsCodeApi;
+    readonly messenger: Messenger;
+
     protected container?: Container;
-    protected vscodeApi: VsCodeApi;
+
+    private startTimeout: number | undefined;
 
     constructor(services: SprottyStarterServices = {}) {
         this.vscodeApi = services.vscodeApi ?? acquireVsCodeApi();
-        this.sendReadyMessage();
+        this.messenger = services.messenger ?? new Messenger(this.vscodeApi);
+        this.startTimeout = window.setTimeout(() => {
+            console.error('The Sprotty webview has not started. Call the start() method of your SprottyStarter to initiate it.');
+        }, 2000);
+    }
+
+    start(): void {
+        window.clearTimeout(this.startTimeout);
+        this.messenger.start();
         this.acceptDiagramIdentifier();
+        this.sendReadyMessage();
     }
 
     protected sendReadyMessage(): void {
-        this.vscodeApi.postMessage({ readyMessage: 'Sprotty Webview ready' } as WebviewReadyMessage);
+        this.messenger.sendNotification(WebviewReadyNotification, HOST_EXTENSION, { readyMessage: 'Sprotty Webview ready' });
     }
 
-    protected acceptDiagramIdentifier(): void {
+    protected acceptDiagramIdentifier(): void {
         console.log('Waiting for diagram identifier...');
-        const eventListener = (message: any) => {
-            if (isDiagramIdentifier(message.data)) {
-                if (this.container) {
-                    const oldIdentifier = this.container.get<SprottyDiagramIdentifier>(SprottyDiagramIdentifier);
-                    const newIdentifier = message.data as SprottyDiagramIdentifier;
-                    oldIdentifier.diagramType = newIdentifier.diagramType;
-                    oldIdentifier.uri = newIdentifier.uri;
-                    const diagramWidget = this.container.get(VscodeDiagramWidget);
-                    diagramWidget.requestModel();
-                } else {
-                    console.log(`...received...`, message);
-                    const diagramIdentifier = message.data as SprottyDiagramIdentifier;
-                    this.container = this.createContainer(diagramIdentifier);
-                    this.addVscodeBindings(this.container, diagramIdentifier);
-                    this.container.get(VscodeDiagramWidget);
-                }
+        this.messenger.onNotification(DiagramIdentifierNotification, newIdentifier => {
+            if (this.container) {
+                const oldIdentifier = this.container.get<SprottyDiagramIdentifier>(SprottyDiagramIdentifier);
+                oldIdentifier.diagramType = newIdentifier.diagramType;
+                oldIdentifier.uri = newIdentifier.uri;
+                const diagramWidget = this.container.get(VscodeDiagramWidget);
+                diagramWidget.requestModel();
+            } else {
+                console.log('...received', newIdentifier);
+                this.container = this.createContainer(newIdentifier);
+                this.addVscodeBindings(this.container, newIdentifier);
+                this.container.get(VscodeDiagramWidget);
             }
-        };
-        window.addEventListener('message', eventListener);
+        });
     }
 
     protected abstract createContainer(diagramIdentifier: SprottyDiagramIdentifier): Container;
 
     protected addVscodeBindings(container: Container, diagramIdentifier: SprottyDiagramIdentifier): void {
         container.bind(VsCodeApi).toConstantValue(this.vscodeApi);
+        container.bind(VsCodeMessenger).toConstantValue(this.messenger);
         container.bind(VscodeDiagramWidget).toSelf().inSingletonScope();
         container.bind(VscodeDiagramWidgetFactory).toFactory(context => {
             return () => context.container.get<VscodeDiagramWidget>(VscodeDiagramWidget);

--- a/packages/sprotty-vscode/package.json
+++ b/packages/sprotty-vscode/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "path": "^0.12.7",
     "sprotty-vscode-protocol": "~0.4.0",
-    "vscode-languageclient": "^8.0.2"
+    "vscode-languageclient": "^8.0.2",
+    "vscode-messenger": "^0.4.3"
   },
   "devDependencies": {
     "@types/node": "^12.12.6",

--- a/packages/sprotty-vscode/src/lsp/lsp-sprotty-editor-provider.ts
+++ b/packages/sprotty-vscode/src/lsp/lsp-sprotty-editor-provider.ts
@@ -44,7 +44,14 @@ export class LspSprottyEditorProvider extends SprottyEditorProvider {
     }
 
     protected override createEndpoint(identifier: SprottyDiagramIdentifier, webviewContainer: vscode.WebviewPanel): WebviewEndpoint {
-        return new LspWebviewEndpoint({ languageClient: this.languageClient, webviewContainer, identifier });
+        const participant = this.messenger.registerWebviewPanel(webviewContainer);
+        return new LspWebviewEndpoint({
+            languageClient: this.languageClient,
+            webviewContainer,
+            messenger: this.messenger,
+            messageParticipant: participant,
+            identifier
+        });
     }
 
     protected override disposeDocument(document: SprottyDocument): void {
@@ -60,7 +67,7 @@ export class LspSprottyEditorProvider extends SprottyEditorProvider {
         for (const document of this.documents) {
             const endpoint = document.endpoint;
             if (endpoint && endpoint.diagramIdentifier && endpoint.diagramIdentifier.clientId === message.clientId) {
-                endpoint.sendToWebview(message);
+                endpoint.sendAction(message);
             }
         }
     }

--- a/packages/sprotty-vscode/src/lsp/lsp-sprotty-view-provider.ts
+++ b/packages/sprotty-vscode/src/lsp/lsp-sprotty-view-provider.ts
@@ -44,7 +44,14 @@ export class LspSprottyViewProvider extends SprottyViewProvider {
     }
 
     protected override createEndpoint(webviewContainer: vscode.WebviewView, identifier?: SprottyDiagramIdentifier): WebviewEndpoint {
-        return new LspWebviewEndpoint({ languageClient: this.languageClient, webviewContainer, identifier });
+        const participant = this.messenger.registerWebviewView(webviewContainer);
+        return new LspWebviewEndpoint({
+            languageClient: this.languageClient,
+            webviewContainer,
+            messenger: this.messenger,
+            messageParticipant: participant,
+            identifier
+        });
     }
 
     protected override didCloseWebview(endpoint: WebviewEndpoint): void {
@@ -58,7 +65,7 @@ export class LspSprottyViewProvider extends SprottyViewProvider {
 
     protected acceptFromLanguageServer(message: ActionMessage): void {
         if (this.endpoint) {
-            this.endpoint.sendToWebview(message);
+            this.endpoint.sendAction(message);
         }
     }
 

--- a/packages/sprotty-vscode/src/lsp/lsp-webview-panel-manager.ts
+++ b/packages/sprotty-vscode/src/lsp/lsp-webview-panel-manager.ts
@@ -44,7 +44,14 @@ export class LspWebviewPanelManager extends WebviewPanelManager {
 
     protected override createEndpoint(identifier: SprottyDiagramIdentifier): LspWebviewEndpoint {
         const webviewContainer = this.createWebview(identifier);
-        return new LspWebviewEndpoint({ languageClient: this.languageClient, webviewContainer, identifier });
+        const participant = this.messenger.registerWebviewPanel(webviewContainer);
+        return new LspWebviewEndpoint({
+            languageClient: this.languageClient,
+            webviewContainer,
+            messenger: this.messenger,
+            messageParticipant: participant,
+            identifier
+        });
     }
 
     protected override didCloseWebview(endpoint: WebviewEndpoint): void {
@@ -59,7 +66,7 @@ export class LspWebviewPanelManager extends WebviewPanelManager {
     protected acceptFromLanguageServer(message: ActionMessage): void {
         for (const endpoint of this.endpoints) {
             if (endpoint.diagramIdentifier && endpoint.diagramIdentifier.clientId === message.clientId) {
-                endpoint.sendToWebview(message);
+                endpoint.sendAction(message);
             }
         }
     }

--- a/packages/sprotty-vscode/src/sprotty-editor-provider.ts
+++ b/packages/sprotty-vscode/src/sprotty-editor-provider.ts
@@ -16,12 +16,14 @@
 
 import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import * as vscode from 'vscode';
+import { Messenger } from 'vscode-messenger';
 import { isWebviewPanel, IWebviewEndpointManager, OpenDiagramOptions, WebviewEndpoint } from './webview-endpoint';
 import { createFileUri, createWebviewHtml, getExtname, serializeUri } from './webview-utils';
 
 export interface SprottyEditorProviderOptions {
     extensionUri: vscode.Uri
     viewType: string
+    messenger?: Messenger
     supportedFileExtensions?: string[];
 }
 
@@ -43,8 +45,10 @@ export class SprottyEditorProvider implements vscode.CustomEditorProvider, IWebv
     }
 
     readonly documents: SprottyDocument[] = [];
+    readonly messenger: Messenger;
 
     constructor(readonly options: SprottyEditorProviderOptions) {
+        this.messenger = options.messenger ?? new Messenger();
     }
 
     /**
@@ -95,7 +99,13 @@ export class SprottyEditorProvider implements vscode.CustomEditorProvider, IWebv
     }
 
     protected createEndpoint(identifier: SprottyDiagramIdentifier, webviewContainer: vscode.WebviewPanel): WebviewEndpoint {
-        return new WebviewEndpoint({ webviewContainer, identifier });
+        const participant = this.messenger.registerWebviewPanel(webviewContainer);
+        return new WebviewEndpoint({
+            webviewContainer,
+            messenger: this.messenger,
+            messageParticipant: participant,
+            identifier
+        });
     }
 
     /**

--- a/packages/sprotty-vscode/src/sprotty-vscode-extension.ts
+++ b/packages/sprotty-vscode/src/sprotty-vscode-extension.ts
@@ -20,6 +20,7 @@ import { Action } from 'sprotty-protocol';
 import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import { SprottyWebview } from './sprotty-webview';
 import { serializeUri } from './webview-utils';
+import { Messenger } from 'vscode-messenger';
 
 /**
  * @deprecated Use `WebviewPanelManager` instead.
@@ -28,9 +29,11 @@ export abstract class SprottyVscodeExtension {
 
     protected readonly webviewMap = new Map<string, SprottyWebview>();
     protected singleton?: SprottyWebview;
+    readonly messenger: Messenger;
 
     constructor(readonly extensionPrefix: string, readonly context: vscode.ExtensionContext) {
         this.registerCommands();
+        this.messenger = new Messenger();
     }
 
     protected registerCommands() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "./configs/base.tsconfig.json",
     "include": [
-        "packages/*/src/**/*.ts"
+        "packages/*/src/**/*.ts",
+        "examples/*/src/**/*.ts"
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5663,6 +5663,25 @@ vscode-languageserver@^8.0.2:
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
+vscode-messenger-common@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/vscode-messenger-common/-/vscode-messenger-common-0.4.3.tgz#362e19eba84906c94521fab41522462b548c5f8c"
+  integrity sha512-6P7OlT7UthfMHe1IcSgv/5f7iELIAXUQ1wCQbciurJo6gwLHFAFqzg/F6TA7wJL5L1/0tyLSKMUWFa0HT/q0GA==
+
+vscode-messenger-webview@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/vscode-messenger-webview/-/vscode-messenger-webview-0.4.3.tgz#80b45af2ee3df5bdef11a80042c8ab63fd8490b1"
+  integrity sha512-/gyU6tDXI/rUFPDkKY7a5al7Y8Pv4OFrnqETcR3hex6o/LjAo6R41n6xmx5J7SC1OXYMjKzqs2og/5KZ09M/gA==
+  dependencies:
+    vscode-messenger-common "^0.4.3"
+
+vscode-messenger@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/vscode-messenger/-/vscode-messenger-0.4.3.tgz#9e07b16ef11335a9a0c21e75a338a5623e639c78"
+  integrity sha512-zOkWT/gXVvksYjtuTfGYWhc2Kn+OFDQl7w2P/LodFufC35tGo6tko28ACSJgvrIFeIhhI11XgMhlCGcT3QZGRA==
+  dependencies:
+    vscode-messenger-common "^0.4.3"
+
 vscode-uri@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"


### PR DESCRIPTION
This PR adds a dependency to [vscode-messenger](https://github.com/TypeFox/vscode-messenger) to handle the communication between extension and webviews. This brings two main advantages:

 * Remove the complexity of handling low-level message objects from sprotty-vscode and delegate it to a dedicated library.
 * Greatly simplify the process to add additional custom messages and respective message handlers.

Adding more custom messages can be useful in large extensions with multiple webview types: using vscode-messenger, it's easy to implement various communication schemes, e.g. send a request or notification from one webview to another, or broadcast from the host extension to all webviews.

In addition, I added a `start()` method to the `SprottyStarter` class in the webview / frontend because it bugged me that the constructor already initiated the whole communication.