### PR TITLE
Added generic type to action handlers

### DIFF
--- a/packages/sprotty-vscode/src/lsp/editing/lsp-label-edit-action-handler.ts
+++ b/packages/sprotty-vscode/src/lsp/editing/lsp-label-edit-action-handler.ts
@@ -28,12 +28,10 @@ import { convertPosition, convertUri, convertWorkspaceEdit, convertRange } from 
 import { LspWebviewEndpoint } from '../lsp-webview-endpoint';
 
 export function addLspLabelEditActionHandler(endpoint: LspWebviewEndpoint): void {
-    const handler = async (action: Action) => {
-        if (LspLabelEditAction.is(action)) {
-            switch (action.editKind) {
-                case 'xref': return chooseCrossReference(action, endpoint);
-                case 'name': return renameElement(action, endpoint);
-            }
+    const handler = async (action: LspLabelEditAction) => {
+        switch (action.editKind) {
+            case 'xref': return chooseCrossReference(action, endpoint);
+            case 'name': return renameElement(action, endpoint);
         }
     };
     endpoint.addActionHandler(LspLabelEditAction.KIND, handler);

--- a/packages/sprotty-vscode/src/lsp/editing/workspace-edit-action-handler.ts
+++ b/packages/sprotty-vscode/src/lsp/editing/workspace-edit-action-handler.ts
@@ -22,10 +22,8 @@ import { convertWorkspaceEdit } from '../lsp-utils';
 import { LspWebviewEndpoint } from '../lsp-webview-endpoint';
 
 export function addWorkspaceEditActionHandler(endpoint: LspWebviewEndpoint): void {
-    const handler = async (action: Action) => {
-        if (WorkspaceEditAction.is(action)) {
-            await vscode.workspace.applyEdit(convertWorkspaceEdit(action.workspaceEdit));
-        }
+    const handler = async (action: WorkspaceEditAction) => {
+        await vscode.workspace.applyEdit(convertWorkspaceEdit(action.workspaceEdit));
     };
     endpoint.addActionHandler(WorkspaceEditAction.KIND, handler);
 };

--- a/packages/sprotty-vscode/src/webview-endpoint.ts
+++ b/packages/sprotty-vscode/src/webview-endpoint.ts
@@ -67,7 +67,7 @@ export class WebviewEndpoint {
     readonly diagramServer?: ActionAcceptor;
     diagramIdentifier?: SprottyDiagramIdentifier;
 
-    protected readonly actionHandlers: Map<string, ActionHandler[]> = new Map();
+    protected readonly actionHandlers: Map<string, ActionHandler<any>[]> = new Map();
     protected readonly disposables: vscode.Disposable[] = [];
 
     constructor(options: WebviewEndpointOptions) {
@@ -180,7 +180,7 @@ export class WebviewEndpoint {
      * Add an action handler for actions that are sent or received. If one or more handlers are registered for an
      * action kind, the corresponding actions are sent to those handlers and are not propagated further.
      */
-    addActionHandler(kind: string, handler: ActionHandler): void {
+    addActionHandler<A extends Action>(kind: string, handler: ActionHandler<A>): void {
         const handlers = this.actionHandlers.get(kind);
         if (handlers) {
             handlers.push(handler);
@@ -192,7 +192,7 @@ export class WebviewEndpoint {
     /**
      * Remove a previously registered action handler.
      */
-    removeActionHandler(kind: string, handler: ActionHandler): void {
+    removeActionHandler<A extends Action>(kind: string, handler: ActionHandler<A>): void {
         const handlers = this.actionHandlers.get(kind);
         if (handlers) {
             const index = handlers.indexOf(handler);
@@ -204,4 +204,4 @@ export class WebviewEndpoint {
 
 }
 
-type ActionHandler = (action: Action) => void | Promise<void>;
+export type ActionHandler<A extends Action = Action> = (action: A) => void | Promise<void>;


### PR DESCRIPTION
The generic type enables to write an action handler that assumes a specific action kind in it parameter type. This makes the registration of action handlers a bit simpler.